### PR TITLE
pointing to release branch of EpiEstimApp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docker-compose.yml
 scripts/*
 !scripts/init
 restart.txt
+.Rproj.user

--- a/site.yml
+++ b/site.yml
@@ -131,7 +131,7 @@ apps:
       
   epiestim:
     type: github
-    spec: jstockwin/EpiEstimApp/inst/app@set_up_for_dide # will need changing to master
+    spec: jstockwin/EpiEstimApp/inst/app@release
     admin: acori
     
 groups:


### PR DESCRIPTION
@richfitz no rush at all but when you have time - this now points to a branch called "release" of the EpiEstimApp. This is just so we can more easily track what branches to on the EpiEstimApp GitHub. Thanks