### PR TITLE
Rename MINT prototype

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -184,8 +184,5 @@ groups:
     - jeff
   admin:
     - rich
-  MVC:    
-    - ellie
-    - guestTester
   india_covid:
     - verg

--- a/site.yml
+++ b/site.yml
@@ -141,14 +141,12 @@ apps:
     admin:
       - alex
 
-  malaria_vector_control_decisions_tool:
+  mint:
     type: github
     spec: mrc-ide/shiny-malaria-UI
     admin: ellie
     auth:
       type: deploy_key
-    groups:
-      - MVC
       
   epiestim:
     type: github


### PR DESCRIPTION
We want to change the url from
`https://shiny.dide.imperial.ac.uk/malaria_vector_control_decisions_tool`
to 
`https://shiny.dide.imperial.ac.uk/mint`

Also remove basic auth, this app should now be publically accessible.