### PR TITLE
Edits to .yml to add orphans app

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -149,7 +149,16 @@ apps:
     type: github
     spec: mrc-ide/covid19-forecasts-orderly-shiny@main
     admin: sbhatia
-
+  
+  covid19-orphans:
+    type: github
+    spec: ImperialCollegeLondon/covid19orphans_shiny
+    admin: ettieunwin
+    auth:
+      type: deploy_key
+    groups:
+    - orphans
+    
 groups:
   dide-internal:
     - rich
@@ -162,3 +171,5 @@ groups:
     - rich
   india_covid:
     - verg
+  orphans:
+    - ettieunwin


### PR DESCRIPTION
@richfitz Here is my first attempt at getting the orphans shiny app served.  It's in a private repo (https://github.com/ImperialCollegeLondon/covid19orphans_shiny) - can give access if necessary. To flag again, it needs to remain private for now but I think I followed those instructions ok.